### PR TITLE
update hisilicon buffering

### DIFF
--- a/servicehisilicon/servicehisilicon.cpp
+++ b/servicehisilicon/servicehisilicon.cpp
@@ -607,7 +607,6 @@ void eServiceHisilicon::netlink_event(int)
 						{
 							m_buffering = true;
 							m_event((iPlayableService*)this, evBuffering);
-							pause();
 						}
 						break;
 					case 2: /* enough */


### PR DESCRIPTION
Let the buffering try to restore itself and do not force a pause. The live stream cannot recover if it's pause continuous.